### PR TITLE
Add animated 'Back to Top' button to ScrollSpy

### DIFF
--- a/src/components/ScrollSpy.tsx
+++ b/src/components/ScrollSpy.tsx
@@ -1,8 +1,11 @@
 import { motion, useReducedMotion } from "framer-motion";
 import { Icon } from "@iconify/react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useScrollSpy } from "../hooks/useScrollSpy";
 import { cn } from "../utils/cn";
+
+const SHOW_BACK_TO_TOP_OFFSET = 480;
+const BOTTOM_PROXIMITY_OFFSET = 120;
 
 interface ScrollSpySection {
   id: string;
@@ -21,26 +24,28 @@ export function ScrollSpy({ sections }: ScrollSpyProps) {
   const [isAtBottom, setIsAtBottom] = useState(false);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined") return undefined;
 
     function handleScroll() {
       const scrollY = window.scrollY || document.documentElement.scrollTop;
       const viewportHeight = window.innerHeight;
       const scrollHeight = document.documentElement.scrollHeight;
 
-      setShowBackToTop(scrollY > 480);
-      setIsAtBottom(viewportHeight + scrollY >= scrollHeight - 120);
+      setShowBackToTop(scrollY > SHOW_BACK_TO_TOP_OFFSET);
+      setIsAtBottom(viewportHeight + scrollY >= scrollHeight - BOTTOM_PROXIMITY_OFFSET);
     }
 
     handleScroll();
     window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
   }, []);
 
-  function handleBackToTop(): void {
+  const handleBackToTop = useCallback((): void => {
     if (typeof window === "undefined") return;
     window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
-  }
+  }, [prefersReducedMotion]);
 
   const buttonAnimate = isAtBottom && !prefersReducedMotion
     ? { opacity: 1, y: 0, rotate: [0, -6, 6, -6, 0], scale: [1, 1.08, 1] }

--- a/src/components/ScrollSpy.tsx
+++ b/src/components/ScrollSpy.tsx
@@ -49,7 +49,7 @@ export function ScrollSpy({ sections }: ScrollSpyProps) {
       top: 0,
       behavior: prefersReducedMotion ? "auto" : "smooth",
     });
-  }
+  }, [prefersReducedMotion]);
 
   const buttonAnimate =
     isAtBottom && !prefersReducedMotion

--- a/src/components/ScrollSpy.tsx
+++ b/src/components/ScrollSpy.tsx
@@ -32,7 +32,9 @@ export function ScrollSpy({ sections }: ScrollSpyProps) {
       const scrollHeight = document.documentElement.scrollHeight;
 
       setShowBackToTop(scrollY > SHOW_BACK_TO_TOP_OFFSET);
-      setIsAtBottom(viewportHeight + scrollY >= scrollHeight - BOTTOM_PROXIMITY_OFFSET);
+      setIsAtBottom(
+        viewportHeight + scrollY >= scrollHeight - BOTTOM_PROXIMITY_OFFSET,
+      );
     }
 
     handleScroll();

--- a/src/components/ScrollSpy.tsx
+++ b/src/components/ScrollSpy.tsx
@@ -1,5 +1,6 @@
-import { motion } from "framer-motion";
-import { useMemo } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Icon } from "@iconify/react";
+import { useEffect, useMemo, useState } from "react";
 import { useScrollSpy } from "../hooks/useScrollSpy";
 import { cn } from "../utils/cn";
 
@@ -15,11 +16,44 @@ interface ScrollSpyProps {
 export function ScrollSpy({ sections }: ScrollSpyProps) {
   const ids = useMemo(() => sections.map((section) => section.id), [sections]);
   const activeId = useScrollSpy(ids);
+  const prefersReducedMotion = useReducedMotion() ?? false;
+  const [showBackToTop, setShowBackToTop] = useState(false);
+  const [isAtBottom, setIsAtBottom] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    function handleScroll() {
+      const scrollY = window.scrollY || document.documentElement.scrollTop;
+      const viewportHeight = window.innerHeight;
+      const scrollHeight = document.documentElement.scrollHeight;
+
+      setShowBackToTop(scrollY > 480);
+      setIsAtBottom(viewportHeight + scrollY >= scrollHeight - 120);
+    }
+
+    handleScroll();
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  function handleBackToTop(): void {
+    if (typeof window === "undefined") return;
+    window.scrollTo({ top: 0, behavior: prefersReducedMotion ? "auto" : "smooth" });
+  }
+
+  const buttonAnimate = isAtBottom && !prefersReducedMotion
+    ? { opacity: 1, y: 0, rotate: [0, -6, 6, -6, 0], scale: [1, 1.08, 1] }
+    : { opacity: 1, y: 0, rotate: 0, scale: 1 };
+
+  const buttonTransition = isAtBottom && !prefersReducedMotion
+    ? { duration: 0.9, repeat: Infinity, repeatDelay: 1.6 }
+    : { duration: 0.2 };
 
   return (
     <nav
       aria-label="Section navigation"
-      className="fixed right-6 top-1/2 hidden -translate-y-1/2 flex-col items-center gap-3 md:flex"
+      className="fixed right-6 top-1/2 hidden -translate-y-1/2 flex-col items-center gap-4 md:flex"
     >
       {sections.map((section) => {
         const isActive = section.id === activeId;
@@ -49,6 +83,27 @@ export function ScrollSpy({ sections }: ScrollSpyProps) {
           </a>
         );
       })}
+      <motion.button
+        type="button"
+        onClick={handleBackToTop}
+        initial={{ opacity: 0, y: 8 }}
+        animate={
+          showBackToTop
+            ? buttonAnimate
+            : { opacity: 0, y: 8, rotate: 0, scale: 0.9 }
+        }
+        whileHover={prefersReducedMotion ? undefined : { scale: 1.08 }}
+        whileTap={prefersReducedMotion ? undefined : { scale: 0.96 }}
+        className={cn(
+          "relative mt-6 inline-flex h-10 w-10 items-center justify-center rounded-full border border-slate-300/60 bg-white/80 text-slate-600 shadow-sm backdrop-blur-md transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-100",
+          !showBackToTop && "pointer-events-none opacity-0",
+          isAtBottom && showBackToTop && "border-transparent bg-rose-500 text-white shadow-lg",
+        )}
+        transition={showBackToTop ? buttonTransition : { duration: 0.2 }}
+        aria-label="Back to top"
+      >
+        <Icon icon="material-symbols:arrow-upward-rounded" className="text-xl" />
+      </motion.button>
     </nav>
   );
 }


### PR DESCRIPTION
Introduces a floating 'Back to Top' button to the ScrollSpy component, which appears after scrolling down and animates when the user reaches the bottom of the page. The button respects reduced motion preferences and uses framer-motion for smooth transitions.