### PR TITLE
Optimize tile interactions for better performance

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,13 +1,5 @@
 import { Icon } from "@iconify/react";
-import {
-  motion,
-  useMotionValue,
-  useReducedMotion,
-  useSpring,
-  useTransform,
-} from "framer-motion";
-import { useCallback } from "react";
-import type { MouseEvent } from "react";
+import { useReducedMotion } from "framer-motion";
 import type { Project } from "../data/projects";
 import { getSkillIcon } from "../data/skills";
 import { cn } from "../utils/cn";
@@ -19,10 +11,8 @@ interface ProjectCardProps {
 }
 
 export function ProjectCard({ project }: ProjectCardProps) {
-  const prefersReducedMotion = useReducedMotion();
+  const prefersReducedMotion = useReducedMotion() ?? false;
   const { theme } = useTheme();
-  const x = useMotionValue(0);
-  const y = useMotionValue(0);
   const techChipClass = cn(
     "chip flex items-center gap-2 !px-3 !py-1 text-xs font-medium",
     themedClass(
@@ -32,43 +22,15 @@ export function ProjectCard({ project }: ProjectCardProps) {
     ),
   );
 
-  const springX = useSpring(x, { stiffness: 150, damping: 12 });
-  const springY = useSpring(y, { stiffness: 150, damping: 12 });
-
-  const rotateX = useTransform(springY, [-30, 30], [8, -8]);
-  const rotateY = useTransform(springX, [-30, 30], [-8, 8]);
-
-  const handleMouseMove = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      if (prefersReducedMotion) return;
-      const { left, top, width, height } =
-        event.currentTarget.getBoundingClientRect();
-      const offsetX = event.clientX - left;
-      const offsetY = event.clientY - top;
-      const centerX = width / 2;
-      const centerY = height / 2;
-      x.set(((offsetX - centerX) / centerX) * 30);
-      y.set(((offsetY - centerY) / centerY) * 30);
-    },
-    [prefersReducedMotion, x, y],
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    if (prefersReducedMotion) return;
-    x.set(0);
-    y.set(0);
-  }, [prefersReducedMotion, x, y]);
-
   return (
-    <motion.div
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+    <div
       className={cn(
         "card-surface h-full space-y-4 border",
         themedClass(theme, "border-white/30", "border-slate-700/60"),
+        prefersReducedMotion
+          ? "transition-colors"
+          : "transform-gpu transition-transform duration-200 ease-out hover:-translate-y-1 hover:shadow-lg",
       )}
-      style={prefersReducedMotion ? undefined : { rotateX, rotateY }}
-      whileHover={prefersReducedMotion ? undefined : { translateY: -6 }}
     >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h3
@@ -116,6 +78,6 @@ export function ProjectCard({ project }: ProjectCardProps) {
           <span aria-hidden="true">→</span>
         </a>
       ) : null}
-    </motion.div>
+    </div>
   );
 }

--- a/src/sections/SkillsSection.tsx
+++ b/src/sections/SkillsSection.tsx
@@ -16,7 +16,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Icon } from "@iconify/react";
-import { motion, useReducedMotion } from "framer-motion";
+import { useReducedMotion } from "framer-motion";
 import React, { useCallback } from "react";
 import { SectionContainer } from "../components/SectionContainer";
 import { SectionHeader } from "../components/SectionHeader";
@@ -31,10 +31,12 @@ function SortableSkill({
   id,
   label,
   isDeveloping,
+  prefersReducedMotion,
 }: {
   id: string;
   label: string;
   isDeveloping?: boolean;
+  prefersReducedMotion: boolean;
 }) {
   const {
     attributes,
@@ -46,7 +48,7 @@ function SortableSkill({
   } = useSortable({ id });
   const style = {
     transform: CSS.Transform.toString(transform),
-    transition,
+    transition: prefersReducedMotion ? "none" : transition,
   };
   const { theme } = useTheme();
   const surfaceClass = themedClass(
@@ -68,21 +70,18 @@ function SortableSkill({
   const skillIcon = skillIcons[label];
 
   return (
-    <motion.li
+    <li
       ref={setNodeRef}
       style={style}
-      layout
       {...attributes}
       {...listeners}
       className={cn(
-        "select-none rounded-full px-5 py-2 text-sm font-medium shadow-md transition-colors",
+        "flex select-none items-center gap-2 rounded-full px-5 py-2 text-sm font-medium shadow-md transition-colors",
         surfaceClass,
         isDeveloping ? developingClass : stableBorderClass,
-        "select-none rounded-full px-5 py-2 text-sm font-medium shadow-md transition-colors flex items-center gap-2",
-        "bg-white/80 text-slate-700 dark:bg-slate-800/70 dark:text-slate-200",
-        isDeveloping
-          ? "border-2 border-dashed border-accent/60 bg-accent/10 text-accent dark:border-accent/60 dark:bg-accent/20 dark:text-accent"
-          : "border border-slate-200/60 dark:border-slate-700/60",
+        prefersReducedMotion
+          ? ""
+          : "will-change-transform transition-transform duration-150 ease-out",
         isDragging && "ring-2 ring-accent",
       )}
     >
@@ -94,7 +93,7 @@ function SortableSkill({
         />
       )}
       {label}
-    </motion.li>
+    </li>
   );
 }
 
@@ -120,20 +119,17 @@ function SkillsBoard({
       onDragEnd={onDragEnd}
     >
       <SortableContext items={skills} strategy={horizontalListSortingStrategy}>
-        <motion.ul
-          layout
-          className="flex flex-wrap gap-3"
-          transition={{ staggerChildren: prefersReducedMotion ? 0 : 0.05 }}
-        >
+        <ul className="flex flex-wrap gap-3">
           {skills.map((skill) => (
             <SortableSkill
               key={skill}
               id={skill}
               label={skill}
               isDeveloping={developingSkills.has(skill)}
+              prefersReducedMotion={prefersReducedMotion}
             />
           ))}
-        </motion.ul>
+        </ul>
       </SortableContext>
     </DndContext>
   );


### PR DESCRIPTION
## Summary
- replace the project card tilt animation with a lightweight hover transform to reduce GPU work on each tile
- simplify the skills board by removing per-item framer-motion layout animations while preserving drag-and-drop behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc41828bb48321b37c82a3757a2a4b