### PR TITLE
Adjust SPA fallbacks to avoid hiding missing assets

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,7 @@
     "cleanUrls": true,
     "rewrites": [
       {
-        "source": "**",
+        "source": "!**/*.*",
         "destination": "/index.html"
       }
     ],

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,5 +3,9 @@
 
 /privacy-policy /index.html 200
 
+# Serve asset-style requests (paths containing an extension) directly so
+# they can 404 when the file is missing instead of falling back to the SPA.
+/*.* /404.html 404
+
 # Fallback all other extension-less routes to the SPA entry point.
 /* /index.html 200


### PR DESCRIPTION
## Summary
- limit the Firebase Hosting SPA rewrite to extension-less routes so asset requests can surface 404s
- add a Cloudflare Pages redirect rule that lets missing asset-style paths return the static 404 page before falling back to index.html

## Testing
- not run (config changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dc463308648321828286d4750b1e78