### PR TITLE
Ensure VisualizeMe JSON editor stays in JSON mode

### DIFF
--- a/src/tools/data-converter.mjs
+++ b/src/tools/data-converter.mjs
@@ -1,3 +1,14 @@
+/* eslint-env node */
+const {
+  console,
+  URL,
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+} = globalThis;
+const global = globalThis;
+
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";

--- a/src/tools/data-converter.mjs
+++ b/src/tools/data-converter.mjs
@@ -1,14 +1,4 @@
 /* eslint-env node */
-const {
-  console,
-  URL,
-  setTimeout,
-  clearTimeout,
-  setInterval,
-  clearInterval,
-} = globalThis;
-const global = globalThis;
-
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -16,6 +6,10 @@ import vm from "node:vm";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import ts from "typescript";
+
+const { console, URL, setTimeout, clearTimeout, setInterval, clearInterval } =
+  globalThis;
+const global = globalThis;
 
 const VERSION = 1;
 const PLACEHOLDER_PREFIX = "__DATA_PLACEHOLDER__";

--- a/src/tools/visualizeme.ts
+++ b/src/tools/visualizeme.ts
@@ -99,6 +99,13 @@ let activeHoverPathKey = null;
 let printer = null;
 let printerSourceFile = null;
 
+function forceJsonMode() {
+  if (inputModeSelect) {
+    inputModeSelect.value = "json";
+  }
+  inputMode = "json";
+}
+
 if (hasTypeScript) {
   printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
   printerSourceFile = ts.createSourceFile(
@@ -1294,6 +1301,7 @@ function openJsonModal() {
   if (!jsonModal) {
     return;
   }
+  forceJsonMode();
   jsonModalEditor.value = jsonInput.value;
   jsonModal.classList.add("is-open");
   jsonModal.setAttribute("aria-hidden", "false");
@@ -1819,6 +1827,7 @@ if (openJsonEditorButton) {
 }
 
 jsonModalApply.addEventListener("click", () => {
+  forceJsonMode();
   jsonInput.value = jsonModalEditor.value;
   const succeeded = renderFromInput();
   if (succeeded) {


### PR DESCRIPTION
## Summary
- ensure the VisualizeMe advanced JSON editor switches the tool back to JSON mode before edits are applied
- prevent saved JSON updates from being reinterpreted as TypeScript so diagrams render correctly
- define required Node globals in the data converter CLI so eslint recognizes them during linting

## Testing
- npm run lint

fixes #150

------
https://chatgpt.com/codex/tasks/task_e_68dc88d8f81883219900baddfb4a2e31