### PR TITLE
Soften collapsed node appearance in VisualizeMe

### DIFF
--- a/src/tools/visualizeme.ts
+++ b/src/tools/visualizeme.ts
@@ -29,6 +29,7 @@ const NodeWidth = 160;
 const NodeHeight = 60;
 const NodeRadius = 18;
 const DiagramPadding = 40;
+const CollapsedNodeFill = "rgba(148, 163, 184, 0.12)";
 const ROOT_KEY = "__root__";
 
 const jsonInput = requireElement<HTMLTextAreaElement>("json-source");
@@ -1060,7 +1061,7 @@ function renderTree(root) {
     rect.setAttribute("height", `${NodeHeight}`);
     rect.setAttribute(
       "fill",
-      collapsed.get(node.pathKey) ? "rgba(148, 163, 184, 0.12)" : "var(--node)",
+      collapsed.get(node.pathKey) ? CollapsedNodeFill : "var(--node)",
     );
     rect.setAttribute("stroke", "var(--node-border)");
     rect.setAttribute("stroke-width", "1.3");
@@ -1185,7 +1186,7 @@ function highlightSelected(nodeId) {
     } else {
       rect.setAttribute(
         "fill",
-        collapsed.get(pathKey) ? "rgba(15, 23, 42, 0.82)" : "var(--node)",
+        collapsed.get(pathKey) ? CollapsedNodeFill : "var(--node)",
       );
       rect.setAttribute("stroke", "var(--node-border)");
     }


### PR DESCRIPTION
## Summary
- add a shared fill constant so collapsed nodes reuse the soft slate tint
- update highlight reset logic to keep collapsed nodes from appearing nearly black

## Testing
- npm run lint

fixes 152

------
https://chatgpt.com/codex/tasks/task_e_68dc8cbbb5248321923bfddd73b4fce9