### PR TITLE
Fix Visualizeme edge gradient creation

### DIFF
--- a/src/tools/visualizeme.ts
+++ b/src/tools/visualizeme.ts
@@ -1235,6 +1235,7 @@ function buildEdgeGradient(svg) {
   edgeGradient.append(edgeStop1, edgeStop2, edgeStop3);
   defs.append(edgeGradient);
   nodePositions.clear();
+  return defs;
 }
 
 function createEdgesGroup(svg) {


### PR DESCRIPTION
## Summary
- return the `<defs>` element when building the edge gradient so the SVG skeleton can mount correctly
- prevent Visualizeme from throwing a Node.appendChild error after uploading a JSON file

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de0e9b3dc48321815bda3d8e7614ea