### PR TITLE
Remove static portfolio seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The repository needs a `FIREBASE_SERVICE_ACCOUNT_KIYAVERSE` secret with deploy a
 
 - `npm run data:to-json -- src/data/projects.ts` exports convertible `export const` values to `src/data/projects.json` alongside round-trip metadata.
 - `npm run data:to-ts -- src/data/projects.json` restores the original TypeScript module (use `--overwrite` to replace an existing file).
-- Pass `--pick projects,educationTimeline` to work with specific exports when a file contains multiple arrays or objects.
+- Pass `--pick projectsFallback,educationFallback` to work with specific exports when a file contains multiple arrays or objects.
 - Open `src/tools/convert.html` in a browser for an all-in-one local UI that handles file drops, selective exports, and downloads without leaving the machine.
 
 ## JSON visualization helper

--- a/src/data/certifications.ts
+++ b/src/data/certifications.ts
@@ -5,16 +5,14 @@ export type Certification = {
   link?: string;
 };
 
-export const certifications: Certification[] = [
+export const CERTIFICATIONS_RESOURCE = "Certifications";
+
+export const certificationsFallback: Certification[] = [];
+
+export const certificationsPlaceholder: Certification[] = [
   {
-    name: "PSI GitHub Foundations",
-    issuer: "PSI",
-    date: "2024",
-    link: "https://www.credly.com/go/FZfrOlFD9pvCvNOiGFvTrA",
-  },
-  {
-    name: "AZ-900 Microsoft Azure Fundamentals",
-    issuer: "Microsoft",
-    date: "2024",
+    name: "Unable to load certifications",
+    issuer: "Please try again later.",
+    date: "—",
   },
 ];

--- a/src/data/education.ts
+++ b/src/data/education.ts
@@ -5,17 +5,15 @@ export type EducationEntry = {
   tech?: string[];
 };
 
-export const educationTimeline: EducationEntry[] = [
+export const EDUCATION_RESOURCE = "Education";
+
+export const educationFallback: EducationEntry[] = [];
+
+export const educationPlaceholder: EducationEntry[] = [
   {
-    school: "Colorado Mountain College",
-    program: "Medical Billing and Coding",
-    dates: "2025 – 2026",
-    tech: ["Medical Coding", "Health Informatics", "Excel"],
-  },
-  {
-    school: "Greater Altoona CTC",
-    program: "Computer and Networking Technology",
-    dates: "2019 — Jun 2025",
-    tech: ["Networking", "Windows", "Cisco", "Linux"],
+    school: "Unable to load education timeline",
+    program: "We couldn't fetch the most recent education data.",
+    dates: "—",
+    tech: ["Please try again later"],
   },
 ];

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -6,58 +6,17 @@ export type ExperienceEntry = {
   tech?: string[];
 };
 
-export const experienceTimeline: ExperienceEntry[] = [
+export const EXPERIENCE_RESOURCE = "Experience";
+
+export const experienceFallback: ExperienceEntry[] = [];
+
+export const experiencePlaceholder: ExperienceEntry[] = [
   {
-    company: "YRAB/CAYAH Research Board",
-    role: "Board Member",
-    dates: "Feb 2025 – Present",
+    company: "Unable to load experience timeline",
+    role: "Please try again later.",
+    dates: "—",
     description:
-      "Served as a board member for youth research and advocacy, contributing to research direction and community impact.",
-    tech: ["Research", "Advocacy", "Leadership"],
-  },
-  {
-    company: "Walmart",
-    role: "Digital / OGP / OPD Associate",
-    dates: "Jun 2025 – Sept 2025",
-    description:
-      "Worked in retail, order picking, product substitutions, order staging, and dispensing as a digital/OGP/OPD associate at Walmart.",
-    tech: [
-      "Retail",
-      "Order Picking",
-      "Product Substitutions",
-      "Order Staging",
-      "Order Dispensing",
-      "Customer Service",
-    ],
-  },
-  {
-    company: "Amazon",
-    role: "Sortation Associate",
-    dates: "Jun 2025 – Jul 2025",
-    description:
-      "Handled picking, packing, stowing, and unloading packages as a sortation associate at Amazon.",
-    tech: ["Picking", "Packing", "Stowing", "Unloading", "Logistics"],
-  },
-  {
-    company: "Shawmut Services LLC (Contract)",
-    role: "Sales Representative",
-    dates: "Nov 2024 – 2024",
-    description:
-      "Contract sales work including voter registration, canvassing, and direct sales for Shawmut Services.",
-    tech: ["Voter Registration", "Canvassing", "Sales", "Customer Service"],
-  },
-  {
-    company: "Google (Contract)",
-    role: "Social Media Management",
-    dates: "Apr 2021 – Jan 2023",
-    description:
-      "Managed community engagement and led technical and administrative teams for Google as a contract social media manager.",
-    tech: [
-      "Community Engagement",
-      "Technical Leadership",
-      "Team Leadership",
-      "Administration",
-      "Customer Service",
-    ],
+      "We weren't able to load experience details from data.sillylittle.tech.",
+    tech: ["Connection issue"],
   },
 ];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -5,23 +5,15 @@ export type Project = {
   link?: string;
 };
 
-export const projects: Project[] = [
+export const PROJECTS_RESOURCE = "Projects";
+
+export const projectsFallback: Project[] = [];
+
+export const projectsPlaceholder: Project[] = [
   {
-    title: "SillyLittleFiles",
+    title: "Projects failed to load",
     description:
-      "A VPN program & documentation focused on secure remote access for small teams.",
-    tech: ["ProtonVPN", "OpenVPN", "JavaScript"],
-  },
-  {
-    title: "Enterprise Virtualization Project",
-    description:
-      "A class project involving enterprise hardware and virtualization.",
-    tech: ["HPE", "Windows Server", "VMWare", "ILO"],
-  },
-  {
-    title: "Placeholder",
-    description:
-      "Hopefully I will gain more cool things to show off once I progress my career.",
-    tech: ["Hope", "Dreams", "Passion", "Love"],
+      "We couldn't reach data.sillylittle.tech to fetch the latest projects.",
+    tech: ["Connection issue"],
   },
 ];

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,15 +1,6 @@
-export const defaultSkills = [
-  "Information Technology Skills",
-  "Customer Service",
-  "Gaining Med Admin skills",
-  "Technical Leadership",
-  "Team Leadership",
-  "Administration",
-  "Research",
-  "Advocacy",
-  "Sales",
-  "Logistics",
-] as const;
+export const SKILLS_RESOURCE = "Skills";
+
+export const skillsFallback: string[] = [];
 
 const skillIconEntries = [
   ["information technology skills", "material-symbols:memory-alt-rounded"],
@@ -66,3 +57,8 @@ const skillIconMap = skillIconEntries.reduce<Record<string, string>>(
 export function getSkillIcon(label: string): string | undefined {
   return skillIconMap[label.trim().toLowerCase()];
 }
+
+export const skillsPlaceholder: string[] = [
+  "Unable to load skills",
+  "Please refresh to try again",
+];

--- a/src/data/socials.ts
+++ b/src/data/socials.ts
@@ -1,26 +1,19 @@
-export const socials = [
+export type SocialLink = {
+  id: string;
+  label: string;
+  href: string;
+  icon: string;
+};
+
+export const SOCIALS_RESOURCE = "Socials";
+
+export const socialsFallback: SocialLink[] = [];
+
+export const socialsPlaceholder: SocialLink[] = [
   {
-    id: "github",
-    label: "GitHub",
-    href: "https://github.com/kiyarose",
-    icon: "mdi:github",
+    id: "socials-unavailable",
+    label: "Socials unavailable",
+    href: "https://status.sillylittle.tech/",
+    icon: "mdi:alert-circle-outline",
   },
-  {
-    id: "instagram",
-    label: "Instagram",
-    href: "https://instagram.com/kitadire",
-    icon: "mdi:instagram",
-  },
-  {
-    id: "linkedin",
-    label: "LinkedIn",
-    href: "https://linkedin.com/in/kiyarose",
-    icon: "mdi:linkedin",
-  },
-  {
-    id: "bluesky",
-    label: "Bluesky",
-    href: "https://bsky.app/profile/sillylittle.tech",
-    icon: "simple-icons:bluesky",
-  },
-] as const;
+];

--- a/src/hooks/useRemoteData.ts
+++ b/src/hooks/useRemoteData.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from "react";
+
+const DATA_BASE_URL = "https://data.sillylittle.tech/data" as const;
+
+export type RemoteDataStatus = "fallback" | "loaded" | "error";
+
+type UseRemoteDataOptions<TData> = {
+  resource: string;
+  fallbackData: TData;
+  placeholderData: TData;
+};
+
+type UseRemoteDataResult<TData> = {
+  data: TData;
+  status: RemoteDataStatus;
+};
+
+export function useRemoteData<TData>(
+  options: UseRemoteDataOptions<TData>,
+): UseRemoteDataResult<TData> {
+  const { resource, fallbackData, placeholderData } = options;
+  const fallbackRef = useRef(fallbackData);
+  const placeholderRef = useRef(placeholderData);
+  const [data, setData] = useState<TData>(fallbackData);
+  const [status, setStatus] = useState<RemoteDataStatus>("fallback");
+
+  useEffect(() => {
+    fallbackRef.current = fallbackData;
+  }, [fallbackData]);
+
+  useEffect(() => {
+    placeholderRef.current = placeholderData;
+  }, [placeholderData]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const controller = new AbortController();
+
+    async function loadRemoteData() {
+      setData(fallbackRef.current);
+      setStatus("fallback");
+
+      try {
+        const response = await fetch(`${DATA_BASE_URL}/${resource}.json`, {
+          method: "GET",
+          headers: { Accept: "application/json" },
+          cache: "no-cache",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Request for ${resource} failed with status ${response.status}`,
+          );
+        }
+
+        const remoteData = (await response.json()) as TData;
+
+        if (!isMounted) {
+          return;
+        }
+
+        setData(remoteData);
+        setStatus("loaded");
+      } catch (error) {
+        if (!isMounted || controller.signal.aborted) {
+          return;
+        }
+
+        console.error(`Failed to load ${resource} data`, error);
+        setData(placeholderRef.current);
+        setStatus("error");
+      }
+    }
+
+    loadRemoteData();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [resource]);
+
+  return { data, status };
+}

--- a/src/sections/CertificationsSection.tsx
+++ b/src/sections/CertificationsSection.tsx
@@ -2,14 +2,25 @@ import { motion, useReducedMotion } from "framer-motion";
 import { Icon } from "@iconify/react";
 import { SectionContainer } from "../components/SectionContainer";
 import { SectionHeader } from "../components/SectionHeader";
-import { certifications } from "../data/certifications";
+import {
+  CERTIFICATIONS_RESOURCE,
+  certificationsFallback,
+  certificationsPlaceholder,
+  type Certification,
+} from "../data/certifications";
 import { useTheme } from "../hooks/useTheme";
+import { useRemoteData } from "../hooks/useRemoteData";
 import { themedClass } from "../utils/themeClass";
 import { cn } from "../utils/cn";
 
 export function CertificationsSection() {
   const prefersReducedMotion = useReducedMotion();
   const { theme } = useTheme();
+  const { data: certificationEntries } = useRemoteData<Certification[]>({
+    resource: CERTIFICATIONS_RESOURCE,
+    fallbackData: certificationsFallback,
+    placeholderData: certificationsPlaceholder,
+  });
 
   return (
     <SectionContainer id="certifications" className="pb-20">
@@ -21,7 +32,7 @@ export function CertificationsSection() {
           eyebrow="Validated Skills"
         />
         <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
-          {certifications.map((cert, index) => (
+          {certificationEntries.map((cert, index) => (
             <motion.div
               key={cert.name}
               className={cn(

--- a/src/sections/EducationSection.tsx
+++ b/src/sections/EducationSection.tsx
@@ -1,12 +1,18 @@
 import { Icon } from "@iconify/react";
 import { motion, useReducedMotion } from "framer-motion";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
 import { SectionContainer } from "../components/SectionContainer";
 import { SectionHeader } from "../components/SectionHeader";
-import { educationTimeline } from "../data/education";
+import {
+  EDUCATION_RESOURCE,
+  educationFallback,
+  educationPlaceholder,
+  type EducationEntry,
+} from "../data/education";
 import { getSkillIcon } from "../data/skills";
 import { useTheme } from "../hooks/useTheme";
+import { useRemoteData } from "../hooks/useRemoteData";
 import type { Theme } from "../providers/theme-context";
 import { themedClass } from "../utils/themeClass";
 import { cn } from "../utils/cn";
@@ -15,6 +21,11 @@ export function EducationSection() {
   const [activeIndex, setActiveIndex] = useState(0);
   const prefersReducedMotion = useReducedMotion() ?? false;
   const { theme } = useTheme();
+  const { data: educationEntries } = useRemoteData<EducationEntry[]>({
+    resource: EDUCATION_RESOURCE,
+    fallbackData: educationFallback,
+    placeholderData: educationPlaceholder,
+  });
 
   const variants = useMemo(
     () => ({
@@ -23,6 +34,15 @@ export function EducationSection() {
     }),
     [],
   );
+
+  useEffect(() => {
+    setActiveIndex((current) => {
+      if (educationEntries.length === 0) {
+        return 0;
+      }
+      return Math.min(current, educationEntries.length - 1);
+    });
+  }, [educationEntries]);
 
   const handleSelectChange = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
@@ -37,7 +57,7 @@ export function EducationSection() {
   return (
     <SectionContainer id="education" className="pb-20">
       <EducationCard
-        options={educationTimeline}
+        options={educationEntries}
         activeIndex={activeIndex}
         onChange={handleSelectChange}
         prefersReducedMotion={prefersReducedMotion}
@@ -49,7 +69,7 @@ export function EducationSection() {
 }
 
 type EducationCardProps = {
-  options: typeof educationTimeline;
+  options: EducationEntry[];
   activeIndex: number;
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   prefersReducedMotion: boolean;
@@ -68,7 +88,16 @@ function EducationCard({
   variants,
   theme,
 }: EducationCardProps) {
-  const activeItem = options[activeIndex];
+  const safeEntry =
+    options.length > 0
+      ? options[Math.min(activeIndex, options.length - 1)]
+      : educationPlaceholder[0];
+
+  if (!safeEntry) {
+    return null;
+  }
+
+  const activeItem = safeEntry;
 
   return (
     <div className="card-surface space-y-8">
@@ -98,7 +127,7 @@ function EducationCard({
 }
 
 type TimelineColumnProps = {
-  options: typeof educationTimeline;
+  options: EducationEntry[];
   activeIndex: number;
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void;
   theme: Theme;
@@ -152,7 +181,7 @@ function TimelineColumn({
 }
 
 type DetailsCardProps = {
-  entry: (typeof educationTimeline)[number];
+  entry: EducationEntry;
   prefersReducedMotion: boolean;
   variants: {
     enter: { opacity: number; y: number };

--- a/src/sections/HeroSection.tsx
+++ b/src/sections/HeroSection.tsx
@@ -1,9 +1,15 @@
 import { motion, useReducedMotion } from "framer-motion";
-import { socials } from "../data/socials";
+import {
+  SOCIALS_RESOURCE,
+  socialsFallback,
+  socialsPlaceholder,
+  type SocialLink,
+} from "../data/socials";
 import { SectionContainer } from "../components/SectionContainer";
 import AdminHint from "../components/AdminHint";
 import { SocialChip } from "../components/SocialChip";
 import { useTheme } from "../hooks/useTheme";
+import { useRemoteData } from "../hooks/useRemoteData";
 import type { Theme } from "../providers/theme-context";
 import { themedClass } from "../utils/themeClass";
 import { cn } from "../utils/cn";
@@ -11,9 +17,10 @@ import { cn } from "../utils/cn";
 type HeroCardProps = {
   prefersReducedMotion: boolean;
   theme: Theme;
+  socialLinks: SocialLink[];
 };
 
-function HeroCard({ prefersReducedMotion, theme }: HeroCardProps) {
+function HeroCard({ prefersReducedMotion, theme, socialLinks }: HeroCardProps) {
   const surfaceGradient = themedClass(
     theme,
     "from-white/90 via-[#ffe9f2]/80 to-accent/15",
@@ -59,7 +66,7 @@ function HeroCard({ prefersReducedMotion, theme }: HeroCardProps) {
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
-          {socials.map((social) => (
+          {socialLinks.map((social) => (
             <SocialChip key={social.id} {...social} />
           ))}
         </div>
@@ -83,10 +90,19 @@ function HeroCard({ prefersReducedMotion, theme }: HeroCardProps) {
 export function HeroSection() {
   const prefersReducedMotion = useReducedMotion() ?? false;
   const { theme } = useTheme();
+  const { data: socialLinks } = useRemoteData<SocialLink[]>({
+    resource: SOCIALS_RESOURCE,
+    fallbackData: socialsFallback,
+    placeholderData: socialsPlaceholder,
+  });
 
   return (
     <SectionContainer id="hero" className="pt-32 pb-20">
-      <HeroCard prefersReducedMotion={prefersReducedMotion} theme={theme} />
+      <HeroCard
+        prefersReducedMotion={prefersReducedMotion}
+        theme={theme}
+        socialLinks={socialLinks}
+      />
     </SectionContainer>
   );
 }

--- a/src/sections/ProjectsSection.tsx
+++ b/src/sections/ProjectsSection.tsx
@@ -1,9 +1,21 @@
 import { SectionContainer } from "../components/SectionContainer";
 import { SectionHeader } from "../components/SectionHeader";
 import { ProjectCard } from "../components/ProjectCard";
-import { projects } from "../data/projects";
+import {
+  PROJECTS_RESOURCE,
+  projectsFallback,
+  projectsPlaceholder,
+  type Project,
+} from "../data/projects";
+import { useRemoteData } from "../hooks/useRemoteData";
 
 export function ProjectsSection() {
+  const { data: projectEntries } = useRemoteData<Project[]>({
+    resource: PROJECTS_RESOURCE,
+    fallbackData: projectsFallback,
+    placeholderData: projectsPlaceholder,
+  });
+
   return (
     <SectionContainer id="projects" className="pb-20">
       <div className="card-surface space-y-8">
@@ -14,7 +26,7 @@ export function ProjectsSection() {
           eyebrow="Cool things I did!"
         />
         <div className="grid gap-4 sm:gap-6 md:grid-cols-2">
-          {projects.map((project) => (
+          {projectEntries.map((project) => (
             <ProjectCard key={project.title} project={project} />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- replace the local portfolio dataset exports with empty fallbacks so sections always hydrate from the remote JSON
- update consumers to import the new fallback constants and fetch shared skill metadata dynamically
- refresh the tooling documentation to reference the new export names

## Testing
- npm run lint
- npm run build -- --logLevel error

resolves #184

------
https://chatgpt.com/codex/tasks/task_e_68de13575c5c8321a3f250e80f1979a1