### PR TITLE
Change Privacy Policy link to kiya.cat

### DIFF
--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -422,7 +422,7 @@ function PolicyIntro() {
       <AdminHint>Kiya Rose</AdminHint>, collect, use, and safeguard personal
       information when you visit{" "}
       <a href="https://kiya.cat" rel="noreferrer">
-        sillylittle.tech
+        kiya.cat
       </a>
       , interact with the contact form, or engage with the analytics services
       that power the site.


### PR DESCRIPTION
Updated the link in the Privacy Policy to point to kiya.cat instead of silylittle.tech.