### PR TITLE
Update education dates from 2026 to 2028

### DIFF
--- a/public/data/Education.json
+++ b/public/data/Education.json
@@ -16,7 +16,7 @@
     {
       "school": "Colorado Mountain College",
       "program": "Medical Billing and Coding",
-      "dates": "2025 – 2026",
+      "dates": "2025 – 2028",
       "tech": [
         "Medical Coding",
         "Health Informatics",


### PR DESCRIPTION
Update Fallback Education Date for CMC from '26 to '28
This pull request makes a minor update to the education dates for the Colorado Mountain College entry in `public/data/Education.json`. The change extends the program duration to reflect new information.